### PR TITLE
dockerfile: resolve latest Go patch version from go.mod minor

### DIFF
--- a/cmd/Dockerfile.nvidia
+++ b/cmd/Dockerfile.nvidia
@@ -48,7 +48,12 @@ RUN dnf install -y wget
 COPY go.mod .
 COPY go.sum .
 
-RUN GO_VERSION=$(sed -En 's/^go +(.*)$/\1/p' go.mod) && \
+RUN GO_MINOR=$(sed -En 's/^go ([0-9]+\.[0-9]+).*/\1/p' go.mod) && \
+    GO_VERSION=$(wget -qO- 'https://go.dev/dl/?mode=json&include=all' | \
+      grep -oE 'go[0-9]+\.[0-9]+\.[0-9]+' | \
+      grep "^go${GO_MINOR}\." | \
+      sort -uV | tail -1 | sed 's/^go//') && \
+    echo "Installing Go ${GO_VERSION}" && \
     wget https://dl.google.com/go/go${GO_VERSION}.${BUILDOS}-${BUILDARCH}.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.${BUILDOS}-${BUILDARCH}.tar.gz && \
     rm go${GO_VERSION}.${BUILDOS}-${BUILDARCH}.tar.gz


### PR DESCRIPTION
Instead of using the exact version pinned in go.mod, query the Go download API at build time to install the latest available patch release for the minor version specified in go.mod.

<!-- Thanks for sending a pull request!

Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature or fix, just one!
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what did you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it

If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering to future generations.
-->

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
